### PR TITLE
Feat: conf 정보 http의 member로 추가

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -9,6 +9,7 @@ Client::~Client(void)
 }
 
 Client::Client(const int fd, const Conf &conf):
+	http_(conf),
 	conf_(conf)
 {
 	identifier_ = fd;
@@ -62,5 +63,5 @@ void Client::Update(void)
 {
 	if (identifier_ == -1)
 		return ;
-	http_.Do(in_, out_, conf_);
+	http_.Do(in_, out_);
 }

--- a/src/client.hpp
+++ b/src/client.hpp
@@ -29,7 +29,7 @@ class Client : public IOEvent
 	std::stringstream out_;
 
 	Http http_;
-	Conf conf_;
+	const Conf conf_;
 };
 
 # endif /* SRC_CLIENT_HPP_ */

--- a/src/http/http.hpp
+++ b/src/http/http.hpp
@@ -8,19 +8,21 @@ class Http
 {
  public:
 	~Http(void);
-	Http(void);
+	Http(const Conf &conf);
 
-	void Do(std::stringstream& in, std::stringstream& out, const Conf &conf);
+	void Do(std::stringstream& in, std::stringstream& out);
  private:
 	Http(const Http& obj);
 	Http& operator=(const Http& obj);
 
-	void Execute(const Conf &conf);
+	void Execute();
 
-	void GenerateError(const Conf &conf, HttpStatus status);
+	void GenerateError(HttpStatus status);
+	HttpStatus Post();
 
 	HttpRequest request_;
 	HttpResponse response_;
+	const Conf &conf_;
 };
 
 #endif /* SRC_HTTP_HTTP_HPP_ */

--- a/src/http/http_error.cpp
+++ b/src/http/http_error.cpp
@@ -15,7 +15,7 @@ static const std::string default_error(const HttpStatus &status, const std::stri
 	return oss.str();
 }
 
-void Http::GenerateError(const Conf& conf, HttpStatus status)
+void Http::GenerateError(HttpStatus status)
 {
 	response_.Clear();
 	response_.set_status(status);
@@ -23,10 +23,10 @@ void Http::GenerateError(const Conf& conf, HttpStatus status)
 	response_.add_header("Content-Type", "text/html");
 	response_.add_header("Connection", "close");
 
-	std::map<int, std::string>::const_iterator it = conf.error_page.find(status);
-	if (it != conf.error_page.end())
+	std::map<int, std::string>::const_iterator it = conf_.error_page.find(status);
+	if (it != conf_.error_page.end())
 	{
-		std::string path = conf.GetPath(it->second);
+		std::string path = conf_.GetPath(it->second);
 		std::ifstream page(path.c_str(), std::ios_base::in);
 		if (page.is_open())
 		{

--- a/src/server.hpp
+++ b/src/server.hpp
@@ -29,7 +29,7 @@ class Server : public IOEvent
 	int	GetAddrInfo(struct addrinfo **info);
 	int CreatSocket(struct addrinfo *info);
 
-	Conf conf_;
+	const Conf conf_;
 };
 
 # endif /* SRC_SERVER_HPP_ */


### PR DESCRIPTION
- http class에 conf를 member로 가지게 함
- http의 method를 호출 할 때, conf 정보를 넘기지 않고 멤버 변수를 참조하도록 수정