### PR TITLE
쿠키와 세션

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,6 +10,8 @@ SRCS	= \
 	server.cpp \
 	client.cpp \
 	http/http.cpp \
+	http/session.cpp \
+	http/cookie.cpp \
 	http/http_request.cpp \
 	http/http_response.cpp \
 	http/http_error.cpp \

--- a/src/http/cookie.cpp
+++ b/src/http/cookie.cpp
@@ -1,0 +1,42 @@
+#include "cookie.hpp"
+
+std::string	Expires() { // 쿠키의 만료시간 설정
+	std::time_t currentTime = std::time(NULL);
+	std::time_t expirationTime = currentTime + 3600; // 1시간(60분 * 60초)
+	std::tm*	expireTimeInfo = std::gmtime(&expirationTime);
+	
+	char expires[100];
+	std::strftime(expires, sizeof(expires), "%a, %d-%b-%Y %H:%M:%S GMT", expireTimeInfo);
+	return expires;
+}
+
+std::string	Domain() { // 쿠키가 전송되는 도메인을 설정 (default: 현재 도메인)
+	return "localhost";
+}
+
+std::string Path() { // 쿠키가 유효한 경로를 설정 (default: 현재 페이지 경로가 적용)
+	return "/";
+}
+
+std::string makeCookie(const std::string & key, const std::string & val)
+{
+	std::string cookie = key + "=" + val + ";";
+
+	bool	expires = true;// 쿠키의 만료시간 설정
+	bool	domain = false;// 쿠키가 전송되는 도메인을 설정 (default: 현재 도메인)
+	bool	path = false;// 쿠키가 유효한 경로를 설정 (default: 현재 페이지 경로가 적용)
+	bool	secure = false; // HTTPS 프로토콜을 통해만 쿠키가 전송되도록 설정
+	bool	httpOnly = true; // JavaScript에서 쿠키에 접근할 수 없음
+
+	if (expires)
+		cookie += "Expires=" + Expires() + ";";
+	if (domain)
+		cookie += "Domain=" + Domain() + ";";
+	if (path)
+		cookie += "Path=" + Path() + ";";
+	if (secure)
+		cookie += "Secure;";
+	if (httpOnly)
+		cookie += "HttpOnly;";
+	return cookie;
+}

--- a/src/http/cookie.hpp
+++ b/src/http/cookie.hpp
@@ -1,0 +1,8 @@
+#ifndef SRC_HTTP_COOKIE_HPP_
+#define SRC_HTTP_COOKIE_HPP_
+#include <string>
+#include <ctime>
+
+std::string makeCookie(const std::string & key, const std::string & val);
+
+#endif /* SRC_HTTP_COOKIE_HPP_ */

--- a/src/http/http_response.hpp
+++ b/src/http/http_response.hpp
@@ -4,6 +4,7 @@
 # include <sstream>
 # include <algorithm>
 # include "http_code.hpp"
+# include "cookie.hpp"
 
 class HttpResponse
 {

--- a/src/http/session.cpp
+++ b/src/http/session.cpp
@@ -5,7 +5,7 @@ Session & Session::GetInstance(void) {
 	return instance;
 }
 
-std::string setSessionId() {
+std::string makeSessionId() {
 	std::ostringstream sessionIdStream;
 	std::srand(static_cast<unsigned int>(std::time(NULL)));
 
@@ -15,7 +15,9 @@ std::string setSessionId() {
 }
 
 std::string	Session::createSession() {
-	std::string sessionId = setSessionId();
+	std::string sessionId = makeSessionId();
+	while (sessionMap.find(sessionId) != sessionMap.end())
+		sessionId = makeSessionId();
 	time_t now = time(NULL);
 	t_session newSession = {sessionId, now + SESSION_TIMEOUT}; // 만료시간 지정
 	sessionMap[sessionId] = newSession;

--- a/src/http/session.cpp
+++ b/src/http/session.cpp
@@ -1,0 +1,34 @@
+#include "session.hpp"
+
+Session & Session::GetInstance(void) {
+	static Session instance;
+	return instance;
+}
+
+std::string setSessionId() {
+	std::ostringstream sessionIdStream;
+	std::srand(static_cast<unsigned int>(std::time(NULL)));
+
+	for (int i = 0; i < 16; ++i)
+		sessionIdStream << std::rand() % 10;
+	return sessionIdStream.str();
+}
+
+std::string	Session::createSession() {
+	std::string sessionId = setSessionId();
+	time_t now = time(NULL);
+	t_session newSession = {sessionId, now + SESSION_TIMEOUT}; // 만료시간 지정
+	sessionMap[sessionId] = newSession;
+	return sessionId;
+}
+
+bool	Session::isSessionValid(const std::string & sessionId) {
+	time_t now = time(NULL);
+	if (sessionMap.find(sessionId) != sessionMap.end()) {
+		if (sessionMap[sessionId].expiryTime > now)
+			return true;
+		else
+			sessionMap.erase(sessionId);
+	}
+	return false;
+}

--- a/src/http/session.hpp
+++ b/src/http/session.hpp
@@ -1,0 +1,26 @@
+#ifndef SRC_HTTP_SESSION_HPP_
+#define SRC_HTTP_SESSION_HPP_
+
+#include "http_response.hpp"
+#include <iostream>
+#include <cstdlib>
+#include <ctime>
+#include <sstream>
+
+#define SESSION_TIMEOUT 1800 // 30분
+
+struct t_session {
+	std::string sessionId;
+	time_t expiryTime;
+};
+
+class Session {
+	public:
+		static Session & GetInstance(void);
+		std::string createSession();
+		bool isSessionValid(const std::string & sessionId);
+	private:
+		std::map<std::string, t_session> sessionMap;
+};
+
+#endif /* SRC_HTTP_SESSION_HPP_ */


### PR DESCRIPTION
관련이슈
#50

기능적인 부분은 구현했습니다.

쿠키를 만들 때
`add_header("Set-Cookie", makeCookie("key", "value"));`
세션을 만들 때
`add_header("Set-Cookie", makeCookie("SessionId", createSession()));`

- 추신
클라이언트가 웹서버에 접근할때 받는 get요청 헤더에 cookie 헤더가 있는지?
있다면 SessionId를 가지고있는지 확인해서 쿠키나 세션을 생성 및 확인 하면 될 것 같습니다