### PR TITLE
Cgi_pass를 항상 절대경로로 받아야 함 && Cgi waitpid는 pid 값이 -1일 때만 하기

### DIFF
--- a/libs/config/block.cpp
+++ b/libs/config/block.cpp
@@ -403,8 +403,11 @@ location_t Block::ParseLocation(const std::vector<std::string> &tokens, size_t &
             }
             Simple::ParseMap(tokens, idx, error_msg, location.fastcgi_param, directive);
         }
-        else if (directive == "fastcgi_pass")
+        else if (directive == "fastcgi_pass") {
             Simple::ParseMap(tokens, idx, error_msg, location.fastcgi_pass, directive);
+            if (error_msg.empty() == false)
+                return location;
+        }
         else if (directive == "try_files")
             location.try_files = Simple::ParseTryFiles(tokens, idx, error_msg);
         else if (directive == "return")

--- a/libs/config/simple.cpp
+++ b/libs/config/simple.cpp
@@ -452,6 +452,10 @@ void Simple::ParseMap(const std::vector<std::string> &tokens, size_t &idx, std::
     }
     const std::string parameter = tokens[idx++];
     const std::string value = tokens[idx++];
+    if (value[0] != '/') {
+        error_msg = "Config: " + directive + ": [ " + value + " ] is not absolute";
+        return;
+    }
     map[parameter] = value;
     ++idx;
     return;

--- a/src/http/cgi.cpp
+++ b/src/http/cgi.cpp
@@ -149,12 +149,13 @@ void Cgi::Write(void)
 
 void Cgi::Update(void)
 {
+	if (pid_ == -1) return;
 	int status = 0;
-	int ret = waitpid(pid_, &status, WNOHANG);
+	const pid_t ret = waitpid(pid_, &status, WNOHANG);
 	if (ret < 0) {
-		std::cerr << "waitpid error: " << strerror(errno) << std::endl;
 		return response_.set_status(kInternalServerError);
 	} else if (ret != 0) {
+		pid_ = -1;
 		if (WIFEXITED(status))
 			response_.set_done(true);
 		else


### PR DESCRIPTION
1. Cgi_pass를 항상 절대경로로 받아야 함
2. Cgi waitpid는 pid 값이 -1일 때만 하기