### PR TITLE
fix: python interal server error

### DIFF
--- a/www/cgi-bin/file_upload.py
+++ b/www/cgi-bin/file_upload.py
@@ -29,7 +29,7 @@ def manage_session() -> tuple:
         cookie['session_id']['path'] = '/'
         cookie['session_id']['httponly'] = True
         cookie['session_id']['secure'] = True
-        cookie['session_id']['samesite'] = 'Lax'
+#        cookie['session_id']['samesite'] = 'Lax'
         expiration = datetime.now() + timedelta(days=7)
         cookie['session_id']['expires'] = expiration.strftime("%a, %d-%b-%Y %H:%M:%S GMT")
         print(cookie.output())  # 'Set-Cookie' 헤더를 출력합니다.


### PR DESCRIPTION
파이썬에서 오류 발생해서 주석처리했어요 
```
STARTLINE[POST /cgi-bin/file_upload.py HTTP/1.1]
- method[POST]
- uri[/cgi-bin/file_upload.py]
REQUEST::URI [/cgi-bin/file_upload.py]
- version[HTTP/1.1]
Header: Host =  localhost:8080
Header: Connection =  keep-alive
Header: Content-Length =  86521
Header: Cache-Control =  max-age=0
Header: sec-ch-ua =  "Chromium";v="116", "Not)A;Brand";v="24", "Google Chrome";v="116"
Header: sec-ch-ua-mobile =  ?0
Header: sec-ch-ua-platform =  "macOS"
Header: Upgrade-Insecure-Requests =  1
Header: Origin =  http://localhost:8080
Header: Content-Type =  multipart/form-data; boundary=----WebKitFormBoundarykUKiuFkf1fJI8sBM
Header: User-Agent =  Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36
Header: Accept =  text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
Header: Sec-Fetch-Site =  same-origin
Header: Sec-Fetch-Mode =  navigate
Header: Sec-Fetch-User =  ?1
Header: Sec-Fetch-Dest =  document
Header: Referer =  http://localhost:8080/file_upload
Header: Accept-Encoding =  gzip, deflate, br
Header: Accept-Language =  ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7,ru;q=0.6
Uri = /cgi-bin/file_upload.py
Url = /cgi-bin/file_upload.py
Path = www/cgi-bin/file_upload.py
EXECUTE!
Cgi::Open - POST(21797)
program = /usr/local/bin/python3
path = www/cgi-bin/file_upload.py
file = file_upload.py
QUERY_STRING=
argx[x] /usr/local/bin/python3
envp[0] CONTENT_LENGTH=86521
envp[1] CONTENT_TYPE=multipart/form-data; boundary=----WebKitFormBoundarykUKiuFkf1fJI8sBM
envp[2] GATEWAY_INTERFACE=CGI/1.1
envp[3] PATH_INFO=www/cgi-bin/file_upload.py
envp[4] REQUEST_METHOD=POST
envp[5] SERVER_PROTOCOL=HTTP/1.1
envp[6] SERVER_SOFTWARE=Webserv/1.0
envp[7] HTTP_ACCEPT=text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
envp[8] HTTP_ACCEPT_ENCODING=gzip, deflate, br
envp[9] HTTP_ACCEPT_LANGUAGE=ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7,ru;q=0.6
envp[10] HTTP_CACHE_CONTROL=max-age=0
envp[11] HTTP_CONNECTION=keep-alive
envp[12] HTTP_CONTENT_LENGTH=86521
envp[13] HTTP_CONTENT_TYPE=multipart/form-data; boundary=----WebKitFormBoundarykUKiuFkf1fJI8sBM
envp[14] HTTP_HOST=localhost:8080
envp[15] HTTP_ORIGIN=http://localhost:8080
envp[16] HTTP_REFERER=http://localhost:8080/file_upload
envp[17] HTTP_SEC_CH_UA="Chromium";v="116", "Not)A;Brand";v="24", "Google Chrome";v="116"
envp[18] HTTP_SEC_CH_UA_MOBILE=?0
envp[19] HTTP_SEC_CH_UA_PLATFORM="macOS"
envp[20] HTTP_SEC_FETCH_DEST=document
envp[21] HTTP_SEC_FETCH_MODE=navigate
envp[22] HTTP_SEC_FETCH_SITE=same-origin
envp[23] HTTP_SEC_FETCH_USER=?1
envp[24] HTTP_UPGRADE_INSECURE_REQUESTS=1
envp[25] HTTP_USER_AGENT=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36
execute
Traceback (most recent call last):
  File "file_upload.py", line 75, in <module>
    session_id, cookie = manage_session()
  File "file_upload.py", line 32, in manage_session
    cookie['session_id']['samesite'] = 'Lax'
  File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/http/cookies.py", line 311, in __setitem__
    raise CookieError("Invalid attribute %r" % (K,))
http.cookies.CookieError: Invalid attribute 'samesite'
CGI Header: Status =  500 Internal Server Error
CGI Header: Content-Type =  text/html
CGI Header: Content-Length =  1734
Cgi::Close - POST(21797)
1763###########################
HTTP/1.1 500 Internal Server Error
CONNECTION: keep-alive
CONTENT-LENGTH: 1763
CONTENT-TYPE: text/html


<!DOCTYPE html>
<html lang="ko">
<head>
    <meta charset="UTF-8">
    <title>File Upload Result</title>
    <style>
        body {
            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
            background-color: #f0f0f0;
            text-align: center;
            padding-top: 50px;
            margin: 0;
        }
        .container {
            background-color: white;
            width: 40%;
            margin: auto;
            padding: 40px;
            border-radi...
###########################
Client::Close
```